### PR TITLE
Feature/send data with playback end event

### DIFF
--- a/Example/Tests/AVPlayerWrapperTests.swift
+++ b/Example/Tests/AVPlayerWrapperTests.swift
@@ -99,7 +99,7 @@ class AVPlayerWrapperTests: XCTestCase {
             default: break
             }
         }
-        wrapper.load(from: LongSource.url, playWhenReady: true, initialTime: 4.0)
+        wrapper.load(from: LongSource.url, playWhenReady: true, initialTime: 4.0, headers: [:])
         wait(for: [expectation], timeout: 20.0)
     }
     
@@ -146,7 +146,8 @@ class AVPlayerWrapperTests: XCTestCase {
         holder.didSeekTo = { seconds in
             expectation.fulfill()
         }
-        wrapper.load(from: LongSource.url, playWhenReady: false, initialTime: 4.0)
+        
+        wrapper.load(from: LongSource.url, playWhenReady: false, initialTime: 4.0, headers: [:])
         wait(for: [expectation], timeout: 20.0)
     }
     

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -168,7 +168,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
     
-    func load(from url: URL, playWhenReady: Bool) {
+    func load(from url: URL, playWhenReady: Bool, headers: [String: Any]? = nil) {
         reset(soft: true)
         _playWhenReady = playWhenReady
 
@@ -176,8 +176,13 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             recreateAVPlayer()
         }
         
+        var options: [String: Any] = [:]
+        if let headers = headers {
+            options = ["AVURLAssetHTTPHeaderFieldsKey": headers]
+        }
+        
         // Set item
-        self._pendingAsset = AVURLAsset(url: url)
+        self._pendingAsset = AVURLAsset(url: url, options: options)
         if let pendingAsset = _pendingAsset {
             pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: {
                 var error: NSError? = nil
@@ -220,10 +225,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
     
-    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?) {
+    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?) {
         _initialTime = initialTime
         self.pause()
-        self.load(from: url, playWhenReady: playWhenReady)
+        self.load(from: url, playWhenReady: playWhenReady, headers: headers)
     }
     
     // MARK: - Util

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -49,8 +49,7 @@ protocol AVPlayerWrapperProtocol: class {
     
     func seek(to seconds: TimeInterval)
     
-    func load(from url: URL, playWhenReady: Bool)
-    
-    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?)
+    func load(from url: URL, playWhenReady: Bool, headers: [String: Any]?)
+    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?)
     
 }

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -50,6 +50,7 @@ protocol AVPlayerWrapperProtocol: class {
     func seek(to seconds: TimeInterval)
     
     func load(from url: URL, playWhenReady: Bool, headers: [String: Any]?)
+    
     func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?)
     
 }

--- a/SwiftAudio/Classes/AudioItem.swift
+++ b/SwiftAudio/Classes/AudioItem.swift
@@ -36,6 +36,11 @@ public protocol InitialTiming {
     func getInitialTime() -> TimeInterval
 }
 
+/// Make your `AudioItem`-subclass conform to this protocol to control enable the ability to set authorization headers.
+public protocol Authorizing {
+    func getHeaders() -> [String: Any]
+}
+
 public class DefaultAudioItem: AudioItem {
     
     public var audioUrl: String
@@ -122,6 +127,27 @@ public class DefaultAudioItemInitialTime: DefaultAudioItem, InitialTiming {
     
     public func getInitialTime() -> TimeInterval {
         return initialTime
+    }
+    
+}
+
+/// An AudioItem that also conforms to the `Authorizing`-protocol
+public class DefaultAudioItemAuthorizing: DefaultAudioItem, Authorizing {
+    
+    public var headers: [String: Any]
+    
+    public override init(audioUrl: String, artist: String?, title: String?, albumTitle: String?, sourceType: SourceType, artwork: UIImage?) {
+        self.headers = [:]
+        super.init(audioUrl: audioUrl, artist: artist, title: title, albumTitle: albumTitle, sourceType: sourceType, artwork: artwork)
+    }
+    
+    public init(audioUrl: String, artist: String?, title: String?, albumTitle: String?, sourceType: SourceType, artwork: UIImage?, headers: [String: Any]) {
+        self.headers = headers
+        super.init(audioUrl: audioUrl, artist: artist, title: title, albumTitle: albumTitle, sourceType: sourceType, artwork: artwork)
+    }
+    
+    public func getHeaders() -> [String: Any] {
+        return headers
     }
     
 }

--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -199,7 +199,7 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     public func stop() {
         self.reset()
         self.wrapper.stop()
-        self.event.playbackEnd.emit(data: .playerStopped)
+        self.event.playbackEnd.emit(data: (reason: .playerStopped, currentItem: self.currentItem, currentTime: self.currentTime, nextItem: nil))
     }
     
     /**
@@ -342,7 +342,7 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     }
     
     func AVWrapperItemDidPlayToEndTime() {
-        self.event.playbackEnd.emit(data: .playedUntilEnd)
+        self.event.playbackEnd.emit(data: (reason: .playedUntilEnd, currentItem: self.currentItem, currentTime: self.currentTime, nextItem: nil))
     }
     
     func AVWrapperDidRecreateAVPlayer() {

--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -161,7 +161,8 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
         
         wrapper.load(from: url,
                      playWhenReady: playWhenReady,
-                     initialTime: (item as? InitialTiming)?.getInitialTime())
+                     initialTime: (item as? InitialTiming)?.getInitialTime(),
+                     headers: (item as? Authorizing)?.getHeaders())
         
         self._currentItem = item
         

--- a/SwiftAudio/Classes/Event.swift
+++ b/SwiftAudio/Classes/Event.swift
@@ -10,7 +10,7 @@ import Foundation
 extension AudioPlayer {
     
     public typealias StateChangeEventData = (AudioPlayerState)
-    public typealias PlaybackEndEventData = (PlaybackEndedReason)
+    public typealias PlaybackEndEventData = (reason: PlaybackEndedReason, currentItem: AudioItem?, currentTime: TimeInterval, nextItem: AudioItem?)
     public typealias SecondElapseEventData = (TimeInterval)
     public typealias FailEventData = (Error?)
     public typealias SeekEventData = (seconds: Int, didFinish: Bool)

--- a/SwiftAudio/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudio/Classes/QueuedAudioPlayer.swift
@@ -119,7 +119,7 @@ public class QueuedAudioPlayer: AudioPlayer {
      - throws: `APError`
      */
     public func next() throws {
-        event.playbackEnd.emit(data: .skippedToNext)
+        event.playbackEnd.emit(data: (reason: .skippedToNext, currentItem: self.currentItem, currentTime: self.currentTime, nextItem: self.nextItems.first))
         let nextItem = try queueManager.next()
         try self.load(item: nextItem, playWhenReady: true)
     }
@@ -128,7 +128,7 @@ public class QueuedAudioPlayer: AudioPlayer {
      Step to the previous item in the queue.
      */
     public func previous() throws {
-        event.playbackEnd.emit(data: .skippedToPrevious)
+        event.playbackEnd.emit(data: (reason: .skippedToPrevious, currentItem: self.currentItem, currentTime: self.currentTime, nextItem: self.nextItems.first))
         let previousItem = try queueManager.previous()
         try self.load(item: previousItem, playWhenReady: true)
     }
@@ -151,7 +151,7 @@ public class QueuedAudioPlayer: AudioPlayer {
      - throws: `APError`
      */
     public func jumpToItem(atIndex index: Int, playWhenReady: Bool = true) throws {
-        event.playbackEnd.emit(data: .jumpedToIndex)
+        event.playbackEnd.emit(data: (reason: .jumpedToIndex, currentItem: self.currentItem, currentTime: self.currentTime, nextItem: self.nextItems.first))
         let item = try queueManager.jump(to: index)
         try self.load(item: item, playWhenReady: playWhenReady)
     }


### PR DESCRIPTION
We sometimes ran into a race condition where self.currentItem was already changed when the the playbackEnd event was handled. This PR sends needed data (currentItem, currentTime, nextItem) as payload with the event to avoid this.