### PR TITLE
Add playback stalled event

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -330,6 +330,10 @@ extension AVPlayerWrapper: AVPlayerItemNotificationObserverDelegate {
     func itemDidPlayToEndTime() {
         delegate?.AVWrapperItemDidPlayToEndTime()
     }
+
+    func playbackStalled() {
+        delegate?.AVWrapperPlaybackStalled()
+    }
     
 }
 

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperDelegate.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperDelegate.swift
@@ -16,6 +16,7 @@ protocol AVPlayerWrapperDelegate: class {
     func AVWrapper(seekTo seconds: Int, didFinish: Bool)
     func AVWrapper(didUpdateDuration duration: Double)
     func AVWrapperItemDidPlayToEndTime()
+    func AVWrapperPlaybackStalled()
     func AVWrapperDidRecreateAVPlayer()
     
 }

--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -342,6 +342,10 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     func AVWrapperItemDidPlayToEndTime() {
         self.event.playbackEnd.emit(data: .playedUntilEnd)
     }
+
+    func AVWrapperPlaybackStalled() {
+        self.event.playbackStalled.emit(data: currentItem)
+    }
     
     func AVWrapperDidRecreateAVPlayer() {
         self.event.didRecreateAVPlayer.emit(data: ())

--- a/SwiftAudio/Classes/Event.swift
+++ b/SwiftAudio/Classes/Event.swift
@@ -11,6 +11,7 @@ extension AudioPlayer {
     
     public typealias StateChangeEventData = (AudioPlayerState)
     public typealias PlaybackEndEventData = (PlaybackEndedReason)
+    public typealias PlaybackStalledEventData = (AudioItem?)
     public typealias SecondElapseEventData = (TimeInterval)
     public typealias FailEventData = (Error?)
     public typealias SeekEventData = (seconds: Int, didFinish: Bool)
@@ -30,6 +31,12 @@ extension AudioPlayer {
          - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.
          */
         public let playbackEnd: AudioPlayer.Event<PlaybackEndEventData> = AudioPlayer.Event()
+
+        /**
+         Emitted when the playback is stalled.
+         - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.
+         */
+        public let playbackStalled: AudioPlayer.Event<PlaybackStalledEventData> = AudioPlayer.Event()
         
         /**
          Emitted when a second is elapsed in the `AudioPlayer`.

--- a/SwiftAudio/Classes/Observer/AVPlayerItemNotificationObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerItemNotificationObserver.swift
@@ -11,6 +11,7 @@ import AVFoundation
 
 protocol AVPlayerItemNotificationObserverDelegate: class {
     func itemDidPlayToEndTime()
+    func playbackStalled()
 }
 
 /**
@@ -42,6 +43,7 @@ class AVPlayerItemNotificationObserver {
         observingItem = item
         isObserving = true
         notificationCenter.addObserver(self, selector: #selector(itemDidPlayToEndTime), name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: item)
+        notificationCenter.addObserver(self, selector: #selector(playbackStalled), name: NSNotification.Name.AVPlayerItemPlaybackStalled, object: item)
     }
     
     /**
@@ -58,6 +60,10 @@ class AVPlayerItemNotificationObserver {
     
     @objc private func itemDidPlayToEndTime() {
         delegate?.itemDidPlayToEndTime()
+    }
+
+    @objc private func playbackStalled() {
+        delegate?.playbackStalled()
     }
     
 }


### PR DESCRIPTION
When losing internet connection and running out of cache while playing a file-based stream on iOS the playback cannot be resumed when the connection is back. To handle this state this PR adds a playbackStalled event.